### PR TITLE
Update Gradle Wrapper from 8.0 to 8.0.1

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=4159b938ec734a8388ce03f52aa8f3c7ed0d31f5438622545de4f83a89b79788
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
+distributionSha256Sum=1b6b558be93f29438d3df94b7dfee02e794b94d9aca4611a92cdb79b6b88e909
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.1-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Update Gradle Wrapper from 8.0 to 8.0.1.

Read the release notes: https://docs.gradle.org/8.0.1/release-notes.html

---

The checksums of the Wrapper JAR and the distribution binary have been successfully verified.

- Gradle release: `8.0.1`
- Distribution (-bin) zip checksum: `1b6b558be93f29438d3df94b7dfee02e794b94d9aca4611a92cdb79b6b88e909`
- Wrapper JAR Checksum: `91941f522fbfd4431cf57e445fc3d5200c85f957bda2de5251353cf11174f4b5`

You can find the reference checksum values at https://gradle.org/release-checksums/

---

🤖 This PR has been created by the [Update Gradle Wrapper](https://github.com/gradle-update/update-gradle-wrapper-action) action.

<details>
<summary>Need help? 🤔</summary>
<br />

If something doesn't look right with this PR please file an issue [here](https://github.com/gradle-update/update-gradle-wrapper-action/issues).
</details>